### PR TITLE
Declare debug topics in advance

### DIFF
--- a/prolog/biomake/biomake.pl
+++ b/prolog/biomake/biomake.pl
@@ -72,6 +72,12 @@
 :- user:op(1103,xfy,+=).
 :- user:op(1104,xfy,=*).
 
+% Declare all debug topics defined in this module
+:- nodebug(poolq).
+:- nodebug(biomake).
+:- nodebug(pattern).
+:- nodebug(bindrule).
+
 % Configuration
 max_recurse_depth(100).
 

--- a/prolog/biomake/cli.pl
+++ b/prolog/biomake/cli.pl
@@ -8,6 +8,11 @@
 % MAIN PROGRAM
 % ----------------------------------------
 
+% Declare all debug topics defined in this module
+:- nodebug(verbose).
+:- nodebug(build).
+:- nodebug(md5).
+
 
 main :-
         current_prolog_flag(argv, Arguments),

--- a/prolog/biomake/gnumake_parser.pl
+++ b/prolog/biomake/gnumake_parser.pl
@@ -11,6 +11,9 @@
 :- use_module(library(biomake/functions)).
 :- use_module(library(biomake/biomake)).
 
+% Declare all debug topics defined in this module
+:- nodebug(makefile).
+
 % Wrapper for reading GNU Makefile
 parse_gnu_makefile(F,M,OptsOut,OptsIn) :-
     parse_gnu_makefile('',F,M,OptsOut,OptsIn).


### PR DESCRIPTION
Potential fix for #31

Here we 'declare' each topic in the relevant module using nodebug/1
(see http://eu.swi-prolog.org/pldoc/man?predicate=debug/1)

In principle this provides some modularity, in practice, we
don't declare the md5 topic in the md5hash module. This is because
this module is loaded using ensure_loaded/1, post-compilation,
and we may want to call debug/1 on this prior to loading.
 Please enter the commit message for your changes. Lines starting