### PR TITLE
If errors are ignored, report

### DIFF
--- a/prolog/biomake/biomake.pl
+++ b/prolog/biomake/biomake.pl
@@ -551,7 +551,10 @@ silent_run_exec(Exec,T,SL,Opts) :-
 
 handle_exec_error(_,0,_,_,_) :- !.
 handle_exec_error(Exec,Err,T,SL,Opts) :-
-        handle_error('Error ~w executing ~w',[Err,Exec],T,SL,Opts).
+        (   get_opt(keep_going_on_error,true,Opts)
+        ->  IgnoreInfo=' (ignored)'
+        ;   IgnoreInfo=''),
+        handle_error('Error ~w executing ~w~w',[Err,Exec,IgnoreInfo],T,SL,Opts).
 
 handle_error(Fmt,Args,T,SL,Opts) :-
         format(string(WhileFmt),"While building ~w: ~w",[T,Fmt]),


### PR DESCRIPTION
If an exec fails, and either `-k` is passed or the line starts `-`, then will report `(ignored)`

Behavior is not consistent with GNU make (on OS X at least). Make will report `(ignored)` if the exec fails and the line starts `-`, but will not report for `-k`. We could easily make consistent by introducing a distinct opt for these two conditions. If this is preferable close this PR and I'll do it that way.